### PR TITLE
japanmesh.toLatLngBounds 追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ japanmesh.toCode(35.70078, 139.71475, 1000)
 
 ### japanmesh.toLatLngBounds(code)
 
-指定した地域メッシュコードから、メッシュの境界インスタンスを取得します。
+指定した地域メッシュコードから、緯度経度の境界オブジェクトを取得します。
 
 ```javascript
 const bounds = japanmesh.toLatLngBounds('53394547')

--- a/README.md
+++ b/README.md
@@ -46,8 +46,33 @@ const { japanmesh } = require('japanmesh')
 
 ```javascript
 japanmesh.toCode(35.70078, 139.71475, 1000)
-
 => '53394547'
+```
+
+### japanmesh.toLatLngBounds(code)
+
+指定した地域メッシュコードから、メッシュの境界インスタンスを取得します。
+
+```javascript
+const bounds = japanmesh.toLatLngBounds('53394547')
+
+bounds.getCenter() // 境界の中央座標
+=> { lat: 35.704166666666666, lng: 139.71875 }
+
+bounds.getNorthEast() // 境界の北東座標
+=> { lat: 35.70833333333333, lng: 139.725 }
+
+bounds.getNorthWest() // 境界の北西座標
+=> { lat: 35.70833333333333, lng: 139.7125 }
+
+bounds.getSouthWest() // 境界の南西座標
+=> { lat: 35.699999999999996, lng: 139.7125 }
+
+bounds.getSouthEast() // 境界の南東座標
+=> { lat: 139.7125, lng: 139.725 }
+
+bounds.contains({ lat: 35.70416666, lng: 139.71875 }) // 境界内か否か
+=> true
 ```
 
 ### japanmesh.toGeoJSON(code, [properties])
@@ -56,7 +81,6 @@ japanmesh.toCode(35.70078, 139.71475, 1000)
 
 ```javascript
 japanmesh.toGeoJSON('53394547')
-
 =>
 {
   "type": "Feature",
@@ -82,7 +106,6 @@ japanmesh.toGeoJSON('53394547')
 
 ```javascript
 japanmesh.getLevel('53394547')
-
 => 1000
 ```
 
@@ -93,7 +116,6 @@ code, level 未指定時は第 1 次地域区画の地域メッシュコード�
 
 ```javascript
 japanmesh.getCodes('53394547', 500)
-
 => [ '533945471', '533945472', '533945473', '533945474' ]
 ```
 

--- a/src/geo/LatLng.ts
+++ b/src/geo/LatLng.ts
@@ -1,0 +1,9 @@
+export default class LatLng {
+  lat: number
+  lng: number
+
+  constructor(lat: number, lng: number) {
+    this.lat = lat
+    this.lng = lng
+  }
+}

--- a/src/geo/LatLngBounds.ts
+++ b/src/geo/LatLngBounds.ts
@@ -37,7 +37,7 @@ export default class LatLngBounds {
   }
 
   getSouthEast(): LatLng {
-    return new LatLng(this.westLng, this.eastLng)
+    return new LatLng(this.southLat, this.eastLng)
   }
 
   contains(latLng: LatLng) {

--- a/src/geo/LatLngBounds.ts
+++ b/src/geo/LatLngBounds.ts
@@ -1,0 +1,53 @@
+import LatLng from './LatLng'
+
+export default class LatLngBounds {
+  private northLat: number
+  private eastLng: number
+  private southLat: number
+  private westLng: number
+
+  constructor(
+    northLat: number,
+    eastLng: number,
+    southLat: number,
+    westLng: number
+  ) {
+    this.northLat = northLat
+    this.eastLng = eastLng
+    this.southLat = southLat
+    this.westLng = westLng
+  }
+
+  getCenter(): LatLng {
+    const lat = (this.northLat + this.southLat) / 2
+    const lng = (this.eastLng + this.westLng) / 2
+    return new LatLng(lat, lng)
+  }
+
+  getNorthEast(): LatLng {
+    return new LatLng(this.northLat, this.eastLng)
+  }
+
+  getNorthWest(): LatLng {
+    return new LatLng(this.northLat, this.westLng)
+  }
+
+  getSouthWest(): LatLng {
+    return new LatLng(this.southLat, this.westLng)
+  }
+
+  getSouthEast(): LatLng {
+    return new LatLng(this.westLng, this.eastLng)
+  }
+
+  contains(latLng: LatLng) {
+    const lat = latLng.lat
+    const lng = latLng.lng
+    return (
+      this.southLat <= lat &&
+      lat <= this.northLat &&
+      this.westLng <= lng &&
+      lng <= this.eastLng
+    )
+  }
+}

--- a/src/japanmesh.ts
+++ b/src/japanmesh.ts
@@ -5,6 +5,8 @@ import {
   LEVEL_80000_CODES,
 } from './constants'
 
+import LatLngBounds from './geo/LatLngBounds'
+
 function isValidCode(code: string) {
   // 桁数チェック
   if (
@@ -239,6 +241,13 @@ function toCodeForIntegrationAreaMesh(lat: number, lng: number, level: number) {
   }
 
   return code
+}
+
+function toLatLngBounds(code: string) {
+  const coordinate = toCoordinate(code)
+  const ne = coordinate[0] // 北東
+  const sw = coordinate[2] // 南西
+  return new LatLngBounds(ne[1], ne[0], sw[1], sw[0])
 }
 
 function toGeoJSON(code: string, properties: object = {}) {
@@ -553,6 +562,7 @@ function isIntegrationAreaMesh(code: string) {
 
 export const japanmesh = {
   toCode,
+  toLatLngBounds,
   toGeoJSON,
   getLevel,
   getCodes,

--- a/src/tests/geo/LatLngBounds.spec.ts
+++ b/src/tests/geo/LatLngBounds.spec.ts
@@ -1,0 +1,49 @@
+import LatLngBounds from '../../geo/LatLngBounds'
+
+test('LatLngBounds.getCenter', () => {
+  const bounds = new LatLngBounds(1, 1, 0, 0)
+  const center = bounds.getCenter()
+  expect(center.lat).toBe(0.5)
+  expect(center.lng).toBe(0.5)
+})
+
+test('LatLngBounds.getNorthEast', () => {
+  const bounds = new LatLngBounds(1, 1, 0, 0)
+  const center = bounds.getNorthEast()
+  expect(center.lat).toBe(1)
+  expect(center.lng).toBe(1)
+})
+
+test('LatLngBounds.getNorthWest', () => {
+  const bounds = new LatLngBounds(1, 1, 0, 0)
+  const center = bounds.getNorthWest()
+  expect(center.lat).toBe(1)
+  expect(center.lng).toBe(0)
+})
+
+test('LatLngBounds.getSouthWest', () => {
+  const bounds = new LatLngBounds(1, 1, 0, 0)
+  const center = bounds.getSouthWest()
+  expect(center.lat).toBe(0)
+  expect(center.lng).toBe(0)
+})
+
+test('LatLngBounds.getSouthEast', () => {
+  const bounds = new LatLngBounds(1, 1, 0, 0)
+  const center = bounds.getSouthEast()
+  expect(center.lat).toBe(0)
+  expect(center.lng).toBe(1)
+})
+
+test('LatLngBounds.contains', () => {
+  const bounds = new LatLngBounds(1, 1, 0, 0)
+  expect(bounds.contains({ lat: 0.5, lng: 0.5 })).toBe(true)
+  expect(bounds.contains({ lat: 1, lng: 1 })).toBe(true)
+  expect(bounds.contains({ lat: 1, lng: 0 })).toBe(true)
+  expect(bounds.contains({ lat: 0, lng: 0 })).toBe(true)
+  expect(bounds.contains({ lat: 0, lng: 1 })).toBe(true)
+  expect(bounds.contains({ lat: -0.1, lng: 0 })).toBe(false)
+  expect(bounds.contains({ lat: 0, lng: -0.1 })).toBe(false)
+  expect(bounds.contains({ lat: 1.1, lng: 0 })).toBe(false)
+  expect(bounds.contains({ lat: 0, lng: 1.1 })).toBe(false)
+})

--- a/src/tests/japanmesh.spec.ts
+++ b/src/tests/japanmesh.spec.ts
@@ -38,6 +38,46 @@ test('japanmesh.toCode: 無効なレベル指定で例外が発生すること',
   expect(() => japanmesh.toCode(35.70078, 139.71475, 6)).toThrow()
 })
 
+test('japanmesh.toLatLngBounds: 存在するコード指定で LatLngBounds オブジェクトが取得できること', () => {
+  expect(japanmesh.toLatLngBounds('5438').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('533945').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('5339452').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('533945465').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('53394547').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('533945471').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('5339454711').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+  expect(japanmesh.toLatLngBounds('53394547112').constructor.name).toEqual(
+    'LatLngBounds'
+  )
+})
+
+test('japanmesh.toLatLngBounds: 無効なコード指定で例外が発生すること', () => {
+  expect(() => japanmesh.toLatLngBounds('9')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('99')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('9999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('999999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('9999999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('99999999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('999999999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('9999999999')).toThrow()
+  expect(() => japanmesh.toLatLngBounds('99999999999')).toThrow()
+})
+
 test('japanmesh.toGeoJSON: 存在するコード指定で GEO JSON が取得できること', () => {
   expect(japanmesh.toGeoJSON('5438')).toEqual(GEO_JSON[5438])
   expect(japanmesh.toGeoJSON('533945')).toEqual(GEO_JSON[533945])


### PR DESCRIPTION
## 参考
- Leaflet: https://leafletjs.com/reference.html#latlngbounds
- GoogleMap: https://developers.google.com/maps/documentation/places/web-service/search-find-place?hl=ja#Bounds
- mapbox: https://docs.maptiler.com/maplibre-gl-native-android/com.mapbox.mapboxsdk.geometry/#latlngbounds
